### PR TITLE
Add TODO comments to skipped tests

### DIFF
--- a/test/ut/php/api/socialactionsAPITest.php
+++ b/test/ut/php/api/socialactionsAPITest.php
@@ -202,6 +202,7 @@ class socialactionsAPITest extends IznikAPITestCase
      * @dataProvider trueFalseProvider
      */
     public function testPopular($share) {
+        // TODO: Re-enable when Facebook API access is restored
         $this->markTestSkipped('Social actions API disabled due to Facebook blocking');
 
         $g = Group::get($this->dbhr, $this->dbhm);

--- a/test/ut/php/include/MessageTest.php
+++ b/test/ut/php/include/MessageTest.php
@@ -1146,6 +1146,7 @@ class MessageTest extends IznikTestCase {
      * @group skip
      */
     public function testMessageIsochrones() {
+        // TODO: Mock Mapbox API or add test isochrone data to make this work without external API
         $this->markTestSkipped('Requires external Mapbox API');
         # Clean up
         $this->dbhm->preExec("DELETE FROM messages_isochrones;");


### PR DESCRIPTION
## Summary
- Added TODO comments to skipped tests as reminders to fix them

## Skipped Tests
- `testPopular` in socialactionsAPITest.php: Facebook API access blocked
- `testMessageIsochrones` in MessageTest.php: Requires external Mapbox API

## Action Required
These tests should be re-enabled when:
1. Facebook API access is restored for social actions
2. Mapbox API is mocked or test isochrone data is added