### PR TITLE
Mark notification POST operations as deprecated

### DIFF
--- a/http/api/notification.php
+++ b/http/api/notification.php
@@ -1,6 +1,12 @@
 <?php
 namespace Freegle\Iznik;
 
+// TODO: DEPRECATED - POST operations (Seen, AllSeen) have been migrated to v2 Go API
+// Can be retired once all FD/MT clients are using v2
+// Migrated: 2025-12-13
+// V2 endpoints: POST /notification/seen, POST /notification/allseen
+// Used by: Both FD and MT for marking notifications as seen
+
 function notification() {
     global $dbhr, $dbhm;
 


### PR DESCRIPTION
## Summary
- Mark notification.php POST operations (Seen, AllSeen) as deprecated
- These have been migrated to v2 Go API

## V2 endpoints
- POST /notification/seen
- POST /notification/allseen

Part of v1 to v2 API migration.