### PR TITLE
fix: Exclude noreply@ilovefreegle.org from chat review email detection

### DIFF
--- a/include/spam/Spam.php
+++ b/include/spam/Spam.php
@@ -370,7 +370,14 @@ class Spam {
         if (!$check && preg_match_all(Message::EMAIL_REGEXP, $message, $matches)) {
             foreach ($matches as $val) {
                 foreach ($val as $email) {
-                    if (!Mail::ourDomain($email) && strpos($email, 'trashnothing') === FALSE && strpos($email, 'yahoogroups') === FALSE) {
+                    # Exclude our domains, partner domains, and our noreply addresses
+                    $isNoreplyOnOurDomain = stripos($email, 'noreply@') === 0 &&
+                        stripos($email, 'ilovefreegle.org') !== FALSE;
+
+                    if (!Mail::ourDomain($email) &&
+                        strpos($email, 'trashnothing') === FALSE &&
+                        strpos($email, 'yahoogroups') === FALSE &&
+                        !$isNoreplyOnOurDomain) {
                         $check = self::REASON_EMAIL;
                     }
                 }

--- a/test/ut/php/include/chatMessagesTest.php
+++ b/test/ut/php/include/chatMessagesTest.php
@@ -467,6 +467,24 @@ class chatMessagesTest extends IznikTestCase {
         $this->assertNull($m->checkReview("something in butt rd"));
     }
 
+    public function testNoReplyEmailNotFlagged() {
+        # noreply@ilovefreegle.org should NOT trigger review - it's a system address
+        # that appears in automated emails. See Spam::checkReview email detection.
+        $m = new ChatMessage($this->dbhr, $this->dbhm);
+
+        # External email should trigger review
+        $this->assertEquals(ChatMessage::REVIEW_SPAM, $m->checkReview("Test email@external.com email"));
+
+        # USER_DOMAIN email should NOT trigger review
+        $this->assertNull($m->checkReview("Test email@" . USER_DOMAIN . " email"));
+
+        # NOREPLY_ADDR should NOT trigger review (this is the bug fix)
+        $this->assertNull($m->checkReview("Test " . NOREPLY_ADDR . " email"));
+
+        # But noreply at external domains SHOULD still trigger review (security check)
+        $this->assertEquals(ChatMessage::REVIEW_SPAM, $m->checkReview("Test noreply@evil.com email"));
+    }
+
     public function testCheckSpam() {
         $m = new ChatMessage($this->dbhr, $this->dbhm);
 


### PR DESCRIPTION
## Summary
- Fixed chat review incorrectly flagging messages containing `noreply@ilovefreegle.org`
- Added specific exclusion for noreply@ addresses on ilovefreegle.org domain
- Ensured external noreply addresses (e.g., `noreply@evil.com`) still trigger review

## Code Quality Review
- **Deficiency Analysis**: Initial fix was too broad (excluded all noreply@*); refined to only exclude noreply@ on ilovefreegle.org
- **Consistency Check**: Follows same pattern as existing trashnothing/yahoogroups exclusions
- **Duplication**: No code duplication introduced

## Test Plan
- [x] `testNoReplyEmailNotFlagged` verifies:
  - External email triggers review
  - USER_DOMAIN email doesn't trigger
  - `noreply@ilovefreegle.org` doesn't trigger (bug fix)
  - `noreply@evil.com` still triggers (security check)