### PR TITLE
fix: Preserve pipe characters in chat messages

### DIFF
--- a/include/chat/ChatMessage.php
+++ b/include/chat/ChatMessage.php
@@ -581,7 +581,9 @@ WHERE chat_messages.chatid = ? AND chat_messages.userid != ? AND seenbyall = 0 A
         }
 
         # Strip any remaining quoted text in replies.
-        $ret['message'] = trim(preg_replace('/\|.*$/m', "", $ret['message']));
+        # The ^ anchor ensures we only strip lines that START with | (email quote convention),
+        # not pipe characters appearing in the middle of text.
+        $ret['message'] = trim(preg_replace('/^\|.*$/m', "", $ret['message']));
         $ret['message'] = trim(preg_replace('/^\>.*$/m', "", $ret['message']));
         $ret['message'] = trim(preg_replace('/\#yiv.*$/m', "", $ret['message']));
 


### PR DESCRIPTION
## Summary
- Fix regex in ChatMessage.php that was incorrectly stripping content after pipe characters in chat messages
- Messages like "chest|upright, size and colour" were being truncated to just "chest"
- Added test coverage for pipe character handling

## Root Cause
The regex `/\|.*$/m` was matching any pipe character followed by content to end of line. This was intended to strip email quote markers (lines starting with `|`) but was too aggressive.

## Fix
Added `^` anchor to make the regex `/^\|.*$/m` only match lines that START with `|`, consistent with the correct implementation in `Message.php` line 3444.

## Code Quality Review
- **Deficiency Analysis**: Fix is minimal and targeted
- **Consistency Check**: Pattern now matches `Message.php` implementation  
- **Duplication**: None introduced
- **Go Code**: Reviewed `iznik-server-go/chat/chatmessage.go` - no similar issue exists (Go code doesn't do quote stripping)

## Test Plan
- [x] New test `testPipeCharacterPreserved` with 3 scenarios:
  - Pipe in middle of text → preserved
  - Multiple pipes → preserved
  - Pipe at start of line (email quote) → stripped
- [x] Related tests pass: `testGroup`, `testStripOurFooter`