### PR TITLE
feat: Add shadow mode archiving for incoming email migration

### DIFF
--- a/scripts/incoming/incoming.php
+++ b/scripts/incoming/incoming.php
@@ -41,11 +41,112 @@ list ($id, $failok) = $r->received(Message::EMAIL, $envfrom, $envto, $msg, NULL,
 if ($id) {
     $rc = $r->route();
     fwrite($logh, "Route of $envfrom => $envto returned $rc\n");
+
+    # Save archive for shadow testing with new Laravel code
+    saveIncomingArchive($dbhr, $envfrom, $envto, $msg, $rc, $id, $r);
+
     exit(0);
 } else if ($failok) {
     fwrite($logh, "Failure ok for $envfrom => $envto returned $rc\n");
+
+    # Save archive even for failok cases
+    saveIncomingArchive($dbhr, $envfrom, $envto, $msg, $rc, NULL, $r);
 } else {
     fwrite($logh, "Failed to parse message for $envfrom => $envto\n");
+
+    # Save archive for failed parses too
+    saveIncomingArchive($dbhr, $envfrom, $envto, $msg, MailRouter::FAILURE, NULL, $r);
+
     exit(1);
+}
+
+/**
+ * Save incoming email archive for shadow testing with new Laravel code.
+ *
+ * Archives are saved to /var/lib/freegle/incoming-archive/ as JSON files.
+ * Each file contains the raw email, envelope info, and legacy routing result.
+ *
+ * To enable archiving, create the directory:
+ *   mkdir -p /var/lib/freegle/incoming-archive
+ *   chown www-data:www-data /var/lib/freegle/incoming-archive
+ *
+ * To disable archiving, remove or rename the directory.
+ *
+ * @param LoggedPDO $dbhr Database handle for reads
+ * @param string $envfrom Envelope sender
+ * @param string $envto Envelope recipient
+ * @param string $rawEmail Raw email content
+ * @param string $routingOutcome Routing result (e.g., MailRouter::APPROVED)
+ * @param int|null $messageId Created message ID (if any)
+ * @param MailRouter $router The MailRouter instance for extracting additional data
+ */
+function saveIncomingArchive($dbhr, $envfrom, $envto, $rawEmail, $routingOutcome, $messageId, $router) {
+    $archiveDir = '/var/lib/freegle/incoming-archive';
+
+    # Only archive if the directory exists (allows easy enable/disable)
+    if (!is_dir($archiveDir)) {
+        return;
+    }
+
+    # Create daily subdirectory for easier management
+    $dateDir = $archiveDir . '/' . date('Y-m-d');
+    if (!is_dir($dateDir)) {
+        @mkdir($dateDir, 0755, TRUE);
+    }
+
+    # Get additional context from the routed message
+    $userId = NULL;
+    $groupId = NULL;
+    $spamType = NULL;
+    $spamReason = NULL;
+    $subject = NULL;
+    $fromAddress = NULL;
+
+    if ($messageId) {
+        # Query the message to get additional details
+        $msg = $dbhr->preQuery("SELECT fromuser, groupid, spamtype, spamreason, subject, fromaddr
+                                FROM messages WHERE id = ?", [$messageId]);
+        if (count($msg) > 0) {
+            $userId = $msg[0]['fromuser'];
+            $groupId = $msg[0]['groupid'];
+            $spamType = $msg[0]['spamtype'];
+            $spamReason = $msg[0]['spamreason'];
+            $subject = $msg[0]['subject'];
+            $fromAddress = $msg[0]['fromaddr'];
+        }
+    }
+
+    $archive = [
+        'version' => 1,
+        'timestamp' => gmdate('Y-m-d\TH:i:s\Z'),
+        'envelope' => [
+            'from' => $envfrom,
+            'to' => $envto,
+        ],
+        'raw_email' => base64_encode($rawEmail),
+        'legacy_result' => [
+            'routing_outcome' => $routingOutcome,
+            'message_id' => $messageId,
+            'user_id' => $userId,
+            'group_id' => $groupId,
+            'spam_type' => $spamType,
+            'spam_reason' => $spamReason,
+            'subject' => $subject,
+            'from_address' => $fromAddress,
+        ],
+    ];
+
+    # Generate unique filename with timestamp and random suffix
+    $filename = sprintf('%s/%s_%06d.json',
+        $dateDir,
+        date('His'),
+        mt_rand(0, 999999)
+    );
+
+    # Write atomically (write to temp, then rename)
+    $tempFile = $filename . '.tmp';
+    if (@file_put_contents($tempFile, json_encode($archive, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES))) {
+        @rename($tempFile, $filename);
+    }
 }
 


### PR DESCRIPTION
## Summary
- Adds optional archiving of incoming emails to support shadow testing of the new Laravel incoming mail processing
- Enable by creating `/var/lib/freegle/incoming-archive` directory
- Archives include raw email, envelope info, and legacy routing outcome for comparison

## How It Works
1. When archiving is enabled, each incoming email is saved to a JSON file
2. The archive includes:
   - Raw email content (base64 encoded)
   - Envelope sender/recipient
   - Legacy routing outcome (message ID, user ID, group ID, spam type/reason)
3. Files are organized by date: `/var/lib/freegle/incoming-archive/YYYY-MM-DD/`
4. Laravel's `mail:incoming:replay` command can process these archives for validation

## Safety
- Archiving is **off by default** - only enabled when the archive directory exists
- Does not affect normal mail processing
- Safe to deploy without impacting production behavior

## Test Plan
1. Deploy to production
2. Create `/var/lib/freegle/incoming-archive` directory to enable archiving
3. Monitor archive files are being created
4. Use Laravel replay command to validate new processing matches legacy

Fixes: Incoming email migration Phase A validation