### PR TITLE
fix: Convert PDOException to DBException in beginTransaction/rollBack

### DIFF
--- a/include/LoggedPDO.php
+++ b/include/LoggedPDO.php
@@ -526,7 +526,11 @@ class LoggedPDO {
 
         $time = microtime(TRUE);
         if ($this->inTransaction()) {
-            $rc = $this->_db->rollBack();
+            try {
+                $rc = $this->_db->rollBack();
+            } catch (\PDOException $e) {
+                throw new DBException("rollBack failed: " . $e->getMessage(), 999, $e);
+            }
         }
 
         $duration = microtime(TRUE) - $time;
@@ -548,7 +552,13 @@ class LoggedPDO {
     public function beginTransaction() {
         $this->doConnect();
         $this->transactionStart = microtime(TRUE);
-        $ret = $this->_db->beginTransaction();
+
+        try {
+            $ret = $this->_db->beginTransaction();
+        } catch (\PDOException $e) {
+            throw new DBException("beginTransaction failed: " . $e->getMessage(), 999, $e);
+        }
+
         $duration = microtime(TRUE) - $this->transactionStart;
         $this->dbwaittime += $duration;
 


### PR DESCRIPTION
## Summary
- Wrap `beginTransaction()` and `rollBack()` in LoggedPDO.php to convert raw `\PDOException` to `DBException`
- This allows the API retry handler in API.php to properly retry the operation instead of returning ret:998

## Root Cause
`ChatRoom::createConversation()` uses `SELECT ... FOR UPDATE` inside a transaction. Under CI load with concurrent Playwright tests creating chat rooms simultaneously, `beginTransaction()` can throw a raw `\PDOException` (lock wait timeout, connection loss). Since `\PDOException` is not `DBException`, the API catch block at API.php:521 treats it as "Something else" and returns ret:998 "Unexpected error" instead of retrying.

## Fix
Convert `\PDOException` to `DBException` in both `beginTransaction()` and `rollBack()`, matching the existing pattern used in `giveUp()` and `doConnect()`.

## Evidence
- Reply-flow test failures occurred in 4 of 7 recent master builds (1987, 1988, 1990, 1995)
- All showed `POST /chat/rooms -> ret: 998` during chat room creation
- The error is specific to the `createConversation` code path which uses transactions with FOR UPDATE locks

## Test Plan
- Existing PHPUnit tests for ChatRoom cover the happy path
- CI Playwright reply-flow test should stop failing intermittently